### PR TITLE
Implement trailing context (/) operator 

### DIFF
--- a/lex_files/test.l
+++ b/lex_files/test.l
@@ -7,7 +7,11 @@
 ^hello      { printf("BOL: ligne commencant par 'hello'\n"); }
 world$      { printf("EOL: ligne finissant par 'world'\n"); }
 ^foo$       { printf("BOL+EOL: ligne exactement 'foo'\n"); }
+
+ab/cd       { printf("TRAILING: 'ab' suivi de 'cd' -> yytext=[%s]\n", yytext); }
 [a-z]+      { printf("mot: %s\n", yytext); }
+[0-9]+/\n   { printf("TRAILING: nombre en fin de ligne -> yytext=[%s]\n", yytext); }
+
 \n          ;
 .           ;
 

--- a/src/file_parsing/definitions/definitions.rs
+++ b/src/file_parsing/definitions/definitions.rs
@@ -143,7 +143,7 @@ pub fn parse_definitions(file: &mut FileInfo) -> Result<Vec<Definition>, String>
             }
             '\n' => {
                 file.it.next();
-                file.line_nb += 1
+                file.line_nb += 1;
             }
             c if WHITESPACE.contains(*c) => {
                 let content = read_spaced_line(file);
@@ -168,10 +168,10 @@ pub fn list_all_states(defs: &[Definition]) -> Vec<(&String, DefinitionState)> {
     for def in defs {
         match def {
             Definition::InclusiveState { name, .. } => {
-                result.push((name, DefinitionState::Inclusive))
+                result.push((name, DefinitionState::Inclusive));
             }
             Definition::ExclusiveState { name, .. } => {
-                result.push((name, DefinitionState::Exclusive))
+                result.push((name, DefinitionState::Exclusive));
             }
             _ => {}
         }
@@ -190,5 +190,5 @@ pub fn get_state_type(defs: &[Definition], state_name: &str) -> Result<Definitio
         .iter()
         .find(|(name, _)| name == &state_name)
         .map(|&(_, typ)| Ok(typ))
-        .unwrap_or_else(|| Err(format!("undeclared start condition {}", state_name)))
+        .unwrap_or_else(|| Err(format!("undeclared start condition {state_name}")))
 }

--- a/src/file_parsing/parsing.rs
+++ b/src/file_parsing/parsing.rs
@@ -19,10 +19,10 @@ fn get_file_content(file_path: &str) -> std::io::Result<String> {
 }
 
 pub fn parsing_lex_file(file_path: &str) -> Result<FilePart, String> {
-    let file_content = match get_file_content(file_path) {
-        Ok(content) => content,
-        Err(_) => return Err(format!("can't open {}", file_path)),
+    let Ok(file_content) = get_file_content(file_path) else {
+        return Err(format!("can't open {file_path}"));
     };
+
     let mut file = FileInfo {
         it: file_content.chars().peekable(),
         line_nb: 0,

--- a/src/file_parsing/rules/condition_state.rs
+++ b/src/file_parsing/rules/condition_state.rs
@@ -14,7 +14,6 @@ fn skip_until_newline_state_block(file: &mut FileInfo) -> Result<(), String> {
             }
             ' ' | '\t' => {
                 file.it.next();
-                continue;
             }
             _ => return Err("unrecognized rule".to_string()),
         }

--- a/src/file_parsing/rules/rules.rs
+++ b/src/file_parsing/rules/rules.rs
@@ -228,7 +228,11 @@ pub fn build_rule_nfa(
     let is_eol = rule.ends_with('$') && !rule.ends_with("\\$");
 
     let rule = if is_bol { &rule[1..] } else { &rule[..] };
-    let rule = if is_eol { &rule[..rule.len() - 1] } else { rule };
+    let rule = if is_eol {
+        &rule[..rule.len() - 1]
+    } else {
+        rule
+    };
 
     let tokens = regex_tokenizer(rule);
     let nfa = build_nfa(&tokens, next_state_id);
@@ -276,8 +280,7 @@ pub fn parse_rules(
                 rules.append(&mut state_rules);
             }
             _ => {
-                let (nfa, action, is_bol, is_eol) =
-                    build_rule_nfa(file, &mut next_state_id, defs)?;
+                let (nfa, action, is_bol, is_eol) = build_rule_nfa(file, &mut next_state_id, defs)?;
                 rules.push(RuleAction {
                     nfa,
                     action,

--- a/src/file_parsing/rules/rules.rs
+++ b/src/file_parsing/rules/rules.rs
@@ -55,12 +55,12 @@ fn append_quoted(rule: &mut String, file: &mut FileInfo) -> Result<(), String> {
 
 fn resolve_def(name: &str, defs: &[Definition]) -> Result<String, String> {
     if name.starts_with(|c: char| c.is_ascii_digit()) {
-        return Ok(format!("{{{}}}", name));
+        return Ok(format!("{{{name}}}"));
     }
-    for def in defs.iter() {
+    for def in defs {
         if let Definition::Definition { name: n, value } = def {
             if n == name {
-                return Ok(format!("({})", value));
+                return Ok(format!("({value})"));
             }
         }
     }
@@ -247,7 +247,7 @@ pub fn parse_rules(
     let mut rules = Vec::new();
     let mut next_state_id = 1;
 
-    while let Some(ch) = file.it.peek().cloned() {
+    while let Some(ch) = file.it.peek().copied() {
         match ch {
             '\n' => {
                 file.line_nb += 1;

--- a/src/file_parsing/rules/rules_states.rs
+++ b/src/file_parsing/rules/rules_states.rs
@@ -11,13 +11,13 @@ use crate::file_parsing::{
 fn extract_state_from_line(file: &mut FileInfo) -> Result<String, String> {
     let mut states_from_line = String::new();
 
-    while let Some(char) = file.it.next() {
+    for char in file.it.by_ref() {
         match char {
             '\n' => {
                 file.line_nb += 1;
                 break;
             }
-            'a'..'z' | 'A'..'Z' | '_' | ',' | '0'..'9' | '*' => {
+            'a'..='z' | 'A'..='Z' | '_' | ',' | '0'..='9' | '*' => {
                 states_from_line.push(char);
             }
             '>' => {
@@ -30,11 +30,11 @@ fn extract_state_from_line(file: &mut FileInfo) -> Result<String, String> {
                 return Ok(states_from_line);
             }
             _ => {
-                return Err(format!("bad <start condition>: {}", char));
+                return Err(format!("bad <start condition>: {char}"));
             }
         }
     }
-    Err(format!("bad <start condition>"))
+    Err("bad <start condition>".to_string())
 }
 
 fn split_state_form_line(states: &str) -> Result<Vec<String>, String> {
@@ -43,7 +43,7 @@ fn split_state_form_line(states: &str) -> Result<Vec<String>, String> {
 
     for char in states.chars() {
         match char {
-            '0'..'9' => {
+            '0'..='9' => {
                 if current_state_name.is_empty() {
                     return Err("bad <start condition>".to_string());
                 }
@@ -105,17 +105,14 @@ fn find_states(
     let mut state_list: Vec<ConditionState> = Vec::new();
 
     for state_name in all_states {
-        match state_name.as_str() {
-            "*" => {
-                let mut star_states = expand_star_for_state(definitions);
+        if let "*" = state_name.as_str() {
+            let mut star_states = expand_star_for_state(definitions);
 
-                state_list.append(&mut star_states);
-            }
-            _ => {
-                let state_type = get_state_type(definitions, state_name)?;
-                let new_def_state = ConditionState::new(state_name.clone(), state_type);
-                state_list.push(new_def_state);
-            }
+            state_list.append(&mut star_states);
+        } else {
+            let state_type = get_state_type(definitions, state_name)?;
+            let new_def_state = ConditionState::new(state_name.clone(), state_type);
+            state_list.push(new_def_state);
         }
     }
     Ok(state_list)

--- a/src/lex_creation/creation.rs
+++ b/src/lex_creation/creation.rs
@@ -14,20 +14,20 @@ use crate::{
     },
 };
 
-pub fn lex_creation(file_parts: FilePart) -> std::io::Result<()> {
+pub fn lex_creation(file_parts: &FilePart) -> std::io::Result<()> {
     let mut file = File::create(LEX_FILE)?;
 
     write_includes(&mut file)?;
     write_defines(&mut file, file_parts.definitions())?;
     write_variables(file_parts.definitions(), &mut file)?;
 
-    tables_creation(&file_parts, &mut file)?;
+    tables_creation(file_parts, &mut file)?;
 
-    write_yy_is_exclusive_state(&file_parts, &mut file)?;
+    write_yy_is_exclusive_state(file_parts, &mut file)?;
 
-    yy_action(&file_parts, &mut file)?;
+    yy_action(file_parts, &mut file)?;
 
-    yy_final(&file_parts, &mut file)?;
+    yy_final(file_parts, &mut file)?;
     create_yy_search_final(file_parts.actions(), &mut file)?;
 
     write_yylex(&mut file, file_parts.in_yylex())?;

--- a/src/lex_creation/functions/yy_action.rs
+++ b/src/lex_creation/functions/yy_action.rs
@@ -73,7 +73,7 @@ fn write_condition_state(
     write!(file, "{}if (", SPACE.repeat(2))?;
     while let Some(state) = condition_state.pop() {
         write!(file, "state != {}", state.name())?;
-        if condition_state.len() != 0 {
+        if !condition_state.is_empty() {
             write!(file, " && ")?;
         }
     }
@@ -96,7 +96,7 @@ pub fn yy_action(file_parts: &FilePart, file: &mut File) -> std::io::Result<()> 
     }
 
     writeln!(file, "void yy_action(int action) {{")?;
-    writeln!(file, "{}switch (action) {{", SPACE)?;
+    writeln!(file, "{SPACE}switch (action) {{")?;
 
     for nb_action in 1..=action_hash.len() {
         writeln!(file, "{}case {}:", SPACE.repeat(2), nb_action)?;
@@ -117,13 +117,13 @@ pub fn yy_action(file_parts: &FilePart, file: &mut File) -> std::io::Result<()> 
                 SPACE.repeat(2)
             )?;
         }
-        writeln!(file, "{}", action)?;
+        writeln!(file, "{action}")?;
         writeln!(file, "{}break;", SPACE.repeat(2))?;
     }
     writeln!(file, "{}default:", SPACE.repeat(2))?;
     writeln!(file, "{}yy_fatal_error(\"not normal\");", SPACE.repeat(3))?;
 
-    writeln!(file, "{}}}", SPACE)?;
+    writeln!(file, "{SPACE}}}")?;
 
     writeln!(file, "}}\n")?;
 

--- a/src/lex_creation/functions/yy_final.rs
+++ b/src/lex_creation/functions/yy_final.rs
@@ -7,15 +7,15 @@ pub fn yy_final(file_parts: &FilePart, file: &mut File) -> std::io::Result<()> {
     let hash = file_parts.map_actions();
 
     for (state, actions) in final_state {
-        writeln!(file, "void final{}(int len_match) {{", state)?;
+        writeln!(file, "void final{state}(int len_match) {{")?;
 
         for elem in actions.iter().rev() {
             let action = hash.get(elem).unwrap();
 
             writeln!(
                 file,
-                "{}yy_push_accepting_state({}, len_match);",
-                SPACE, action
+                "{}yy_push_accepting_state({}, {}, len_match);",
+                SPACE, action, state
             )?;
         }
         writeln!(file, "}}")?;

--- a/src/lex_creation/tables/mod.rs
+++ b/src/lex_creation/tables/mod.rs
@@ -2,3 +2,4 @@ pub mod table;
 mod yy_accept;
 mod yy_ec;
 mod yy_nxt;
+mod yy_trailing;

--- a/src/lex_creation/tables/mod.rs
+++ b/src/lex_creation/tables/mod.rs
@@ -3,3 +3,4 @@ mod yy_accept;
 mod yy_ec;
 mod yy_nxt;
 mod yy_trailing;
+mod yy_trailing_accept;

--- a/src/lex_creation/tables/table.rs
+++ b/src/lex_creation/tables/table.rs
@@ -4,6 +4,7 @@ use crate::file_parsing::FilePart;
 
 use super::{
     yy_accept::yy_accept, yy_ec::create_yy_ec, yy_nxt::create_yy_nxt, yy_trailing::yy_trailing,
+    yy_trailing_accept::yy_trailing_accept,
 };
 
 pub fn tables_creation(file_parts: &FilePart, file: &mut File) -> std::io::Result<()> {
@@ -13,6 +14,7 @@ pub fn tables_creation(file_parts: &FilePart, file: &mut File) -> std::io::Resul
 
     yy_accept(file_parts.dfa(), file)?;
     yy_trailing(file_parts.dfa(), file)?;
+    yy_trailing_accept(file_parts.dfa(), file)?;
 
     Ok(())
 }

--- a/src/lex_creation/tables/table.rs
+++ b/src/lex_creation/tables/table.rs
@@ -2,7 +2,9 @@ use std::fs::File;
 
 use crate::file_parsing::FilePart;
 
-use super::{yy_accept::yy_accept, yy_ec::create_yy_ec, yy_nxt::create_yy_nxt};
+use super::{
+    yy_accept::yy_accept, yy_ec::create_yy_ec, yy_nxt::create_yy_nxt, yy_trailing::yy_trailing,
+};
 
 pub fn tables_creation(file_parts: &FilePart, file: &mut File) -> std::io::Result<()> {
     let eq_hash = create_yy_ec(file_parts.dfa().charset(), file)?;
@@ -10,6 +12,7 @@ pub fn tables_creation(file_parts: &FilePart, file: &mut File) -> std::io::Resul
     create_yy_nxt(file_parts.dfa(), &eq_hash, file)?;
 
     yy_accept(file_parts.dfa(), file)?;
+    yy_trailing(file_parts.dfa(), file)?;
 
     Ok(())
 }

--- a/src/lex_creation/tables/yy_ec.rs
+++ b/src/lex_creation/tables/yy_ec.rs
@@ -36,7 +36,7 @@ pub fn create_yy_ec(
                 write!(file, "{}", SPACE)?;
             }
         } else {
-            writeln!(file, "\n{}}} ;\n", SPACE.to_string())?;
+            writeln!(file, "\n{}}} ;\n", SPACE)?;
         }
     }
 

--- a/src/lex_creation/tables/yy_nxt.rs
+++ b/src/lex_creation/tables/yy_nxt.rs
@@ -24,7 +24,7 @@ fn write_yy_nxt(transition_table: &[Vec<usize>], file: &mut File) -> std::io::Re
             } else if index != state.len() - 1 {
                 write!(file, ",{}", SPACE)?;
             } else {
-                writeln!(file, "")?;
+                writeln!(file)?;
             }
         }
         if index != transition_table.len() - 1 {

--- a/src/lex_creation/tables/yy_trailing.rs
+++ b/src/lex_creation/tables/yy_trailing.rs
@@ -1,0 +1,35 @@
+use std::{fs::File, io::Write};
+
+use crate::{lex_creation::SPACE, regex::dfa::DFA};
+
+pub fn yy_trailing(dfa: &DFA, file: &mut File) -> std::io::Result<()> {
+    let nb_state = dfa.transitions().len();
+    let mut tab = vec![0u8; nb_state];
+
+    for &state in &dfa.trailing_states {
+        if state < nb_state {
+            tab[state] = 1;
+        }
+    }
+
+    writeln!(file, "\nconst int yy_trailing[{}] =", nb_state)?;
+    writeln!(file, "{}{{", SPACE)?;
+    write!(file, "{}", SPACE.repeat(2))?;
+
+    for (index, value) in tab.iter().enumerate() {
+        write!(file, "{}", value)?;
+        if index != 0 && index % 10 == 0 {
+            write!(file, ",")?;
+            if index != tab.len() - 1 {
+                write!(file, "\n{}", SPACE.repeat(2))?;
+            }
+        } else if index != tab.len() - 1 {
+            write!(file, ",{}", SPACE)?;
+        } else {
+            writeln!(file)?;
+        }
+    }
+    writeln!(file, "{}}} ;\n", SPACE)?;
+
+    Ok(())
+}

--- a/src/lex_creation/tables/yy_trailing_accept.rs
+++ b/src/lex_creation/tables/yy_trailing_accept.rs
@@ -1,0 +1,35 @@
+use std::{fs::File, io::Write};
+
+use crate::{lex_creation::SPACE, regex::dfa::DFA};
+
+pub fn yy_trailing_accept(dfa: &DFA, file: &mut File) -> std::io::Result<()> {
+    let nb_state = dfa.transitions().len();
+    let mut tab = vec![0u8; nb_state];
+
+    for &state in &dfa.trailing_final_states {
+        if state < nb_state {
+            tab[state] = 1;
+        }
+    }
+
+    writeln!(file, "\nconst int yy_trailing_accept[{}] =", nb_state)?;
+    writeln!(file, "{}{{", SPACE)?;
+    write!(file, "{}", SPACE.repeat(2))?;
+
+    for (index, value) in tab.iter().enumerate() {
+        write!(file, "{}", value)?;
+        if index != 0 && index % 10 == 0 {
+            write!(file, ",")?;
+            if index != tab.len() - 1 {
+                write!(file, "\n{}", SPACE.repeat(2))?;
+            }
+        } else if index != tab.len() - 1 {
+            write!(file, ",{}", SPACE)?;
+        } else {
+            writeln!(file)?;
+        }
+    }
+    writeln!(file, "{}}} ;\n", SPACE)?;
+
+    Ok(())
+}

--- a/src/lex_creation/templates/includes.c
+++ b/src/lex_creation/templates/includes.c
@@ -16,7 +16,7 @@ int input(void);
 int unput(int c);
 int yywrap(void);
 int yylex(void);
-void yy_push_accepting_state(int state, int len_match);
+void yy_push_accepting_state(int action, int dfa_state, int len_match);
 void yy_init_buffer(void);
 void yy_init_accepting_stack(void);
 void yy_if_no_match(char *last_pos);

--- a/src/lex_creation/templates/libl_functions.c
+++ b/src/lex_creation/templates/libl_functions.c
@@ -54,6 +54,7 @@ t_buffer buffer;
 int yy_init = 0;		/* whether we need to initialize */
 int yy_start = -1;	/* start state number */
 int yy_at_bol = 1;	/* 1 if current position is at beginning of line */
+int yy_trailing_len = 0;
 
 void yy_fatal_error (const char* msg )
 {
@@ -237,8 +238,13 @@ int yy_at_eol(void) {
 void yy_if_match() {
 	a_elem matching_state = yy_pop_accepting_state();
 
-	
-	yy_set_yytext(matching_state);
+	if (yy_trailing_len > 0) {
+		a_elem tc = { matching_state.state, yy_trailing_len };
+		yy_set_yytext(tc);
+		yy_trailing_len = 0;
+	} else {
+		yy_set_yytext(matching_state);
+	}
 	yy_action(matching_state.state);
 	yy_at_bol = (yyleng > 0 && yytext[yyleng - 1] == '\n') ? 1 : 0;
 	char *after_match = buffer.str + yyleng;

--- a/src/lex_creation/templates/libl_functions.c
+++ b/src/lex_creation/templates/libl_functions.c
@@ -9,9 +9,10 @@
 #define YY_CHAR_TO_INT(c) ((uint8_t) (c))
 
 
-extern const unsigned char yy_ec[256];           // tableau externe
-extern const unsigned int yy_nxt[][256]; // ici, 256 est connu               // transition de l'automate
-extern const int yy_accept[];               // états finaux
+extern const unsigned char yy_ec[256];
+extern const unsigned int yy_nxt[][256];
+extern const int yy_accept[];
+extern const int yy_trailing_accept[];
 
 void yy_search_final(int state, int len);
 void yy_if_match(void);
@@ -25,6 +26,7 @@ FILE *yyin = NULL, *yyout = NULL;
 
 typedef struct accept_elem {
 	int state;
+	int dfa_state;
 	size_t len_match;
 } a_elem;
 
@@ -84,12 +86,13 @@ void yy_increase_accepting_stack_len(void) {
 		yy_fatal_error( "out of dynamic memory in increase_accepting_stack_len()" );
 	stack.capacity *= 2;
 }
-void yy_push_accepting_state(int state, int len_match) {
+void yy_push_accepting_state(int action, int dfa_state, int len_match) {
 	int index = stack.len;
 
 	if (stack.len == stack.capacity)
 		yy_increase_accepting_stack_len();
-	stack.t[index].state = state;
+	stack.t[index].state = action;
+	stack.t[index].dfa_state = dfa_state;
 	stack.t[index].len_match = len_match;
 	stack.len++;
 }
@@ -99,6 +102,7 @@ a_elem yy_pop_accepting_state(void) {
 	int index = stack.len - 1;
 
 	pop.state = stack.t[index].state;
+	pop.dfa_state = stack.t[index].dfa_state;
 	pop.len_match = stack.t[index].len_match;
 
 	stack.len--;
@@ -238,8 +242,8 @@ int yy_at_eol(void) {
 void yy_if_match() {
 	a_elem matching_state = yy_pop_accepting_state();
 
-	if (yy_trailing_len > 0) {
-		a_elem tc = { matching_state.state, yy_trailing_len };
+	if (yy_trailing_len > 0 && yy_trailing_accept[matching_state.dfa_state]) {
+		a_elem tc = { matching_state.state, matching_state.dfa_state, yy_trailing_len };
 		yy_set_yytext(tc);
 		yy_trailing_len = 0;
 	} else {

--- a/src/lex_creation/templates/variables.c
+++ b/src/lex_creation/templates/variables.c
@@ -4,6 +4,7 @@ extern int yyleng;
 
 typedef struct accept_elem {
 	int state;
+	int dfa_state;
 	size_t len_match;
 } a_elem;
 
@@ -30,6 +31,7 @@ extern int yy_start;	/* start state number */
 extern int clean_flag;
 extern int yy_trailing_len;
 extern const int yy_trailing[];
+extern const int yy_trailing_accept[];
 
 
 change_me_in_variables!

--- a/src/lex_creation/templates/variables.c
+++ b/src/lex_creation/templates/variables.c
@@ -28,6 +28,8 @@ extern t_buffer buffer;
 extern int yy_init;		/* whether we need to initialize */
 extern int yy_start;	/* start state number */
 extern int clean_flag;
+extern int yy_trailing_len;
+extern const int yy_trailing[];
 
 
 change_me_in_variables!

--- a/src/lex_creation/templates/yylex.c
+++ b/src/lex_creation/templates/yylex.c
@@ -70,6 +70,7 @@ int yylex(void) {
 			current_state = 0;
 			next_state = 0;
 			len_match = 0;
+			yy_trailing_len = 0;
 			clean_flag = 0;
 		}
 		current_state = next_state;

--- a/src/lex_creation/templates/yylex.c
+++ b/src/lex_creation/templates/yylex.c
@@ -26,6 +26,7 @@ int yylex(void) {
 	}
 
 	len_match = 0;
+	yy_trailing_len = 0;
 	current_state = yy_start;
 	last_accepting_state = yy_start;
 
@@ -47,8 +48,10 @@ int yylex(void) {
 		c = *pos;
 		len_match++;
 		unsigned char yy_c = yy_ec[YY_CHAR_TO_INT(c)];
-		
+
 		int next_state = yy_nxt[current_state][yy_c];
+		if (yy_trailing[next_state])
+			yy_trailing_len = len_match;
 		if ( yy_accept[next_state] )
 		{
 			yy_search_final(next_state, len_match);

--- a/src/lex_creation/write.rs
+++ b/src/lex_creation/write.rs
@@ -39,7 +39,7 @@ pub fn write_defines(file: &mut File, definitions: &[Definition]) -> std::io::Re
             _ => continue,
         }
     }
-    writeln!(file, "")?;
+    writeln!(file)?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
         Ok(elems) => elems,
     };
 
-    match lex_creation(file_parts) {
+    match lex_creation(&file_parts) {
         Ok(()) => {}
         Err(error) => eprintln!("Error: {}", error),
     }

--- a/src/regex/dfa/dfa.rs
+++ b/src/regex/dfa/dfa.rs
@@ -51,6 +51,14 @@ pub fn build_dfa(nfa: NFA) -> DFA {
         visited.insert(current.clone());
         let current_id = *state_map.get(&current).unwrap();
 
+        if current
+            .state
+            .iter()
+            .any(|s| nfa.trailing_states.contains(s))
+        {
+            dfa.trailing_states.insert(current_id);
+        }
+
         let mut new_transitions = Vec::with_capacity(ascii_chars.len());
 
         for &ch in &ascii_chars {

--- a/src/regex/dfa/dfa.rs
+++ b/src/regex/dfa/dfa.rs
@@ -59,6 +59,14 @@ pub fn build_dfa(nfa: NFA) -> DFA {
             dfa.trailing_states.insert(current_id);
         }
 
+        if current
+            .state
+            .iter()
+            .any(|s| nfa.trailing_final_states.contains(s))
+        {
+            dfa.trailing_final_states.insert(current_id);
+        }
+
         let mut new_transitions = Vec::with_capacity(ascii_chars.len());
 
         for &ch in &ascii_chars {

--- a/src/regex/dfa/mod.rs
+++ b/src/regex/dfa/mod.rs
@@ -42,6 +42,7 @@ pub struct DFA {
     pub charset: HashSet<char>,
     pub nfa_states: HashMap<usize, Vec<usize>>,
     pub trailing_states: HashSet<usize>,
+    pub trailing_final_states: HashSet<usize>,
 }
 
 impl DFA {
@@ -52,6 +53,7 @@ impl DFA {
             charset: HashSet::new(),
             nfa_states: HashMap::new(),
             trailing_states: HashSet::new(),
+            trailing_final_states: HashSet::new(),
         }
     }
 

--- a/src/regex/dfa/mod.rs
+++ b/src/regex/dfa/mod.rs
@@ -41,6 +41,7 @@ pub struct DFA {
     pub final_states: HashSet<usize>,
     pub charset: HashSet<char>,
     pub nfa_states: HashMap<usize, Vec<usize>>,
+    pub trailing_states: HashSet<usize>,
 }
 
 impl DFA {
@@ -50,6 +51,7 @@ impl DFA {
             final_states: HashSet::new(),
             charset: HashSet::new(),
             nfa_states: HashMap::new(),
+            trailing_states: HashSet::new(),
         }
     }
 

--- a/src/regex/nfa/at_least.rs
+++ b/src/regex/nfa/at_least.rs
@@ -61,6 +61,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([2]),
+            ..NFA::new()
         };
 
         // Transition de 0 à 1 avec le caractère 'a'
@@ -139,6 +140,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([3]),
+            ..NFA::new()
         };
 
         // Transitions pour le NFA
@@ -190,6 +192,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([4]),
+            ..NFA::new()
         };
 
         // Définir plusieurs transitions

--- a/src/regex/nfa/concatenate.rs
+++ b/src/regex/nfa/concatenate.rs
@@ -22,6 +22,7 @@ pub fn concatenate(mut left: NFA, mut right: NFA) -> NFA {
     NFA {
         transitions: left.transitions,
         final_states: right.final_states,
+        ..NFA::new()
     }
 }
 
@@ -36,6 +37,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([2]),
+            ..NFA::new()
         };
 
         // Transition de 0 à 1 avec le caractère 'a'
@@ -63,6 +65,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([4]),
+            ..NFA::new()
         };
 
         // Transition de 0 à 1 avec le caractère 'c'
@@ -133,6 +136,7 @@ mod tests {
         let mut right = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([3]),
+            ..NFA::new()
         };
 
         right.transitions.insert(

--- a/src/regex/nfa/from_char.rs
+++ b/src/regex/nfa/from_char.rs
@@ -18,6 +18,7 @@ pub fn from_char(c: char, state_id: &mut usize) -> NFA {
     NFA {
         transitions,
         final_states: HashSet::from([final_state]),
+        ..NFA::new()
     }
 }
 

--- a/src/regex/nfa/mod.rs
+++ b/src/regex/nfa/mod.rs
@@ -22,6 +22,7 @@ pub struct NFA {
     pub transitions: HashMap<usize, Vec<Transition>>,
     pub final_states: HashSet<usize>,
     pub trailing_states: HashSet<usize>,
+    pub trailing_final_states: HashSet<usize>,
 }
 
 impl NFA {
@@ -30,6 +31,7 @@ impl NFA {
             transitions: HashMap::new(),
             final_states: HashSet::new(),
             trailing_states: HashSet::new(),
+            trailing_final_states: HashSet::new(),
         }
     }
 

--- a/src/regex/nfa/mod.rs
+++ b/src/regex/nfa/mod.rs
@@ -21,6 +21,7 @@ pub struct Transition {
 pub struct NFA {
     pub transitions: HashMap<usize, Vec<Transition>>,
     pub final_states: HashSet<usize>,
+    pub trailing_states: HashSet<usize>,
 }
 
 impl NFA {
@@ -28,6 +29,7 @@ impl NFA {
         Self {
             transitions: HashMap::new(),
             final_states: HashSet::new(),
+            trailing_states: HashSet::new(),
         }
     }
 

--- a/src/regex/nfa/nfa.rs
+++ b/src/regex/nfa/nfa.rs
@@ -34,9 +34,16 @@ pub fn build_nfa(tokens: &[Token], start_id: &mut usize) -> NFA {
                         new_nfa
                     }
                 },
-                Operator::Concatenation | Operator::TrailingContext => {
+                Operator::Concatenation => {
                     let (left, right) = pop_last_two(&mut stack);
                     concatenate(left, right)
+                }
+                Operator::TrailingContext => {
+                    let (left, right) = pop_last_two(&mut stack);
+                    let boundary = left.final_states.clone();
+                    let mut combined = concatenate(left, right);
+                    combined.trailing_states = boundary;
+                    combined
                 }
                 Operator::Or => {
                     let (left, right) = pop_last_two(&mut stack);

--- a/src/regex/nfa/nfa.rs
+++ b/src/regex/nfa/nfa.rs
@@ -43,6 +43,7 @@ pub fn build_nfa(tokens: &[Token], start_id: &mut usize) -> NFA {
                     let boundary = left.final_states.clone();
                     let mut combined = concatenate(left, right);
                     combined.trailing_states = boundary;
+                    combined.trailing_final_states = combined.final_states.clone();
                     combined
                 }
                 Operator::Or => {
@@ -261,6 +262,61 @@ mod tests {
         let result = build_nfa(&tokens, &mut 1);
 
         assert_eq!(result.final_states.len(), 2); // 2 états finaux
+    }
+
+    #[test]
+    fn test_build_nfa_trailing_context() {
+        // ab/cd : trailing_states doit pointer sur les états finaux de "ab"
+        // start_id=1 → a:1, b:2, c:3, d:4
+        let tokens = vec![
+            Token::Char('a'),
+            Token::Char('b'),
+            Token::Operator(Operator::Concatenation),
+            Token::Char('c'),
+            Token::Char('d'),
+            Token::Operator(Operator::Concatenation),
+            Token::Operator(Operator::TrailingContext),
+        ];
+        let nfa = build_nfa(&tokens, &mut 1);
+
+        assert_eq!(nfa.trailing_states, HashSet::from([2]));
+        assert_eq!(nfa.final_states, HashSet::from([4]));
+        assert_ne!(nfa.trailing_states, nfa.final_states);
+    }
+
+    #[test]
+    fn test_build_nfa_trailing_context_single_chars() {
+        // a/b : trailing_states = final de "a" = {1}, final de "ab" = {2}
+        let tokens = vec![
+            Token::Char('a'),
+            Token::Char('b'),
+            Token::Operator(Operator::TrailingContext),
+        ];
+        let nfa = build_nfa(&tokens, &mut 1);
+
+        assert_eq!(nfa.trailing_states, HashSet::from([1]));
+        assert_eq!(nfa.final_states, HashSet::from([2]));
+        assert_eq!(nfa.trailing_final_states, HashSet::from([2]));
+        assert_ne!(nfa.trailing_states, nfa.trailing_final_states);
+    }
+
+    #[test]
+    fn test_build_nfa_trailing_final_states_distinct_from_boundary() {
+        // ab/cd : trailing_states = {2} (frontière), trailing_final_states = {4} (fin du lookahead)
+        let tokens = vec![
+            Token::Char('a'),
+            Token::Char('b'),
+            Token::Operator(Operator::Concatenation),
+            Token::Char('c'),
+            Token::Char('d'),
+            Token::Operator(Operator::Concatenation),
+            Token::Operator(Operator::TrailingContext),
+        ];
+        let nfa = build_nfa(&tokens, &mut 1);
+
+        assert_eq!(nfa.trailing_states, HashSet::from([2]));
+        assert_eq!(nfa.trailing_final_states, HashSet::from([4]));
+        assert!(nfa.trailing_states.is_disjoint(&nfa.trailing_final_states));
     }
 
     // Test pour des expressions vides et erreurs avec des quantificateurs invalides

--- a/src/regex/nfa/or.rs
+++ b/src/regex/nfa/or.rs
@@ -16,6 +16,7 @@ pub fn or(left: NFA, right: NFA) -> NFA {
     NFA {
         transitions,
         final_states,
+        ..NFA::new()
     }
 }
 
@@ -33,6 +34,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([1]),
+            ..NFA::new()
         };
 
         nfa.transitions.insert(
@@ -51,6 +53,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([2]),
+            ..NFA::new()
         };
 
         nfa.transitions.insert(

--- a/src/regex/nfa/or.rs
+++ b/src/regex/nfa/or.rs
@@ -3,6 +3,8 @@ use super::NFA;
 pub fn or(left: NFA, right: NFA) -> NFA {
     let mut transitions = left.transitions;
     let mut final_states = left.final_states;
+    let mut trailing_states = left.trailing_states;
+    let mut trailing_final_states = left.trailing_final_states;
 
     for (state, mut trans) in right.transitions {
         transitions
@@ -12,11 +14,14 @@ pub fn or(left: NFA, right: NFA) -> NFA {
     }
 
     final_states.extend(right.final_states);
+    trailing_states.extend(right.trailing_states);
+    trailing_final_states.extend(right.trailing_final_states);
 
     NFA {
         transitions,
         final_states,
-        ..NFA::new()
+        trailing_states,
+        trailing_final_states,
     }
 }
 
@@ -95,5 +100,59 @@ mod tests {
 
         // Vérification des états finaux
         assert_eq!(result.final_states, HashSet::from([1, 2]));
+    }
+
+    #[test]
+    fn test_or_trailing_states_empty_when_none() {
+        let result = or(create_test_nfa_a(), create_test_nfa_b());
+        assert!(result.trailing_states.is_empty());
+    }
+
+    #[test]
+    fn test_or_preserves_trailing_states_from_left() {
+        let mut nfa_a = create_test_nfa_a();
+        nfa_a.trailing_states = HashSet::from([1]);
+        let nfa_b = create_test_nfa_b();
+
+        let result = or(nfa_a, nfa_b);
+        assert_eq!(result.trailing_states, HashSet::from([1]));
+    }
+
+    #[test]
+    fn test_or_merges_trailing_states_from_both() {
+        let mut nfa_a = create_test_nfa_a();
+        nfa_a.trailing_states = HashSet::from([1]);
+        let mut nfa_b = create_test_nfa_b();
+        nfa_b.trailing_states = HashSet::from([2]);
+
+        let result = or(nfa_a, nfa_b);
+        assert_eq!(result.trailing_states, HashSet::from([1, 2]));
+    }
+
+    #[test]
+    fn test_or_preserves_trailing_final_states_from_left() {
+        let mut nfa_a = create_test_nfa_a();
+        nfa_a.trailing_final_states = HashSet::from([1]);
+        let nfa_b = create_test_nfa_b();
+
+        let result = or(nfa_a, nfa_b);
+        assert_eq!(result.trailing_final_states, HashSet::from([1]));
+    }
+
+    #[test]
+    fn test_or_merges_trailing_final_states_from_both() {
+        let mut nfa_a = create_test_nfa_a();
+        nfa_a.trailing_final_states = HashSet::from([1]);
+        let mut nfa_b = create_test_nfa_b();
+        nfa_b.trailing_final_states = HashSet::from([2]);
+
+        let result = or(nfa_a, nfa_b);
+        assert_eq!(result.trailing_final_states, HashSet::from([1, 2]));
+    }
+
+    #[test]
+    fn test_or_trailing_final_states_empty_when_none() {
+        let result = or(create_test_nfa_a(), create_test_nfa_b());
+        assert!(result.trailing_final_states.is_empty());
     }
 }

--- a/src/regex/nfa/range.rs
+++ b/src/regex/nfa/range.rs
@@ -67,6 +67,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([2]),
+            ..NFA::new()
         };
 
         nfa.transitions.insert(

--- a/src/regex/nfa/repeat_exact.rs
+++ b/src/regex/nfa/repeat_exact.rs
@@ -38,6 +38,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([2]),
+            ..NFA::new()
         };
 
         nfa.transitions.insert(

--- a/src/regex/nfa/utils.rs
+++ b/src/regex/nfa/utils.rs
@@ -44,6 +44,7 @@ mod tests {
         let mut nfa = NFA {
             transitions: HashMap::new(),
             final_states: HashSet::from([2]),
+            ..NFA::new()
         };
 
         nfa.transitions.insert(

--- a/src/regex/tests_regex.rs
+++ b/src/regex/tests_regex.rs
@@ -70,7 +70,7 @@ fn test_regex_simple_or_multiple_chars() {
     // ab -> a concat b, cd -> c concat d, puis | entre les deux
     let nfa = build_nfa(&tokens, &mut 1);
 
-    assert!(nfa.final_states.len() >= 1);
+    assert!(!nfa.final_states.is_empty());
     assert!(nfa.transitions.len() >= 3);
 }
 
@@ -85,7 +85,7 @@ fn test_regex_nested_or() {
     assert_eq!(tokens[2], Token::Char('c'));
     assert_eq!(tokens[3], Token::Operator(Operator::Or));
     assert_eq!(tokens[4], Token::Operator(Operator::Or));
-    assert!(nfa.final_states.len() >= 1);
+    assert!(!nfa.final_states.is_empty());
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn test_regex_star_with_or() {
     let nfa = build_nfa(&tokens, &mut 1);
 
     // boucle sur un choix entre a et b
-    assert!(nfa.final_states.len() >= 1);
+    assert!(!nfa.final_states.is_empty());
     assert!(nfa.transitions.len() >= 3);
 }
 
@@ -136,6 +136,35 @@ fn test_regex_long_concat_with_kleene() {
     let nfa = build_nfa(&tokens, &mut 1);
 
     // a concat b concat c*
-    assert!(nfa.final_states.len() >= 1);
+    assert!(!nfa.final_states.is_empty());
     assert!(nfa.transitions.len() >= 4);
+}
+
+#[test]
+fn test_regex_trailing_context_sets_trailing_states() {
+    let tokens = regex_tokenizer("ab/cd");
+    let nfa = build_nfa(&tokens, &mut 1);
+
+    assert!(!nfa.trailing_states.is_empty());
+    assert!(nfa.trailing_states.is_disjoint(&nfa.final_states));
+}
+
+#[test]
+fn test_regex_trailing_context_or_preserves_trailing_states() {
+    // Régression : combine_nfa utilise or() en boucle, les trailing_states
+    // ne doivent pas être perdues après la fusion avec d'autres règles.
+    use crate::regex::combine_nfa::combine_nfa;
+
+    let tokens_trailing = regex_tokenizer("ab/cd");
+    let nfa_trailing = build_nfa(&tokens_trailing, &mut 1);
+    let expected = nfa_trailing.trailing_states.clone();
+
+    let tokens_other = regex_tokenizer("xyz");
+    let nfa_other = build_nfa(&tokens_other, &mut 10);
+
+    let combined = combine_nfa(vec![nfa_trailing, nfa_other]);
+
+    for state in expected {
+        assert!(combined.trailing_states.contains(&state));
+    }
 }

--- a/src/regex/tokenizer/tokenizer.rs
+++ b/src/regex/tokenizer/tokenizer.rs
@@ -68,8 +68,7 @@ mod tests {
     use super::*;
 
     fn tok(regex: &str) -> Vec<Token> {
-        let token_list = regex_tokenizer(&regex.to_string());
-        token_list
+        regex_tokenizer(regex)
     }
 
     #[test]

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,3 @@
-faire trailing context
-
 array or pointer
 
 compression des tables -> https://stackoverflow.com/questions/29139162/dfa-state-transition-table-compression


### PR DESCRIPTION
- Add trailing_states and trailing_final_states to NFA/DFA structs,
    propagated through or(), concatenate() and DFA construction
  - Generate yy_trailing[] and yy_trailing_accept[] tables
  - Add dfa_state field to a_elem so yy_if_match can distinguish
trailing
    vs non-trailing final states at the correct DFA state
  - Fix yy_trailing_len reset on lexer restart (EC2)
  - Known limitation: dangerous trailing context (overlapping alphabets
    between left and right patterns) is not supported